### PR TITLE
chore: add metadata to the Nix WeTest package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,13 @@
         '';
 
         doCheck = true;
+
+        meta = {
+          description = "Tests automation utility for EPICS";
+          mainProgram = "wetest";
+          license = epnix.lib.licenses.epics;
+          maintainers = with epnix.lib.maintainers; [minijackson];
+        };
       };
 
       devShells.default = pkgs.mkShell {


### PR DESCRIPTION
`mainProgram` is used by `nix run` and `nix bundle`.

cc @stephane-cea